### PR TITLE
replace Joda-Time with with java.time API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,6 @@
                          
                          [cheshire "5.13.0"]
                          [clj-commons/fs "1.6.312"]
-                         [clj-time "0.15.2"]
                          [digest "1.4.10"]
                          [org.apache.commons/commons-compress "1.28.0"]
                          [org.ini4j/ini4j "0.5.4"]
@@ -35,7 +34,6 @@
                  [cheshire]
                  [digest]
                  [clj-commons/fs]
-                 [clj-time]
                  [org.apache.commons/commons-compress]
                  [org.ini4j/ini4j]
                  [org.tcrawley/dynapath]
@@ -60,8 +58,8 @@
                                              puppetlabs.kitchensink.core-test true}
                               :reflection {puppetlabs.kitchensink.file [{:line 62}]
                                            puppetlabs.kitchensink.core [{:line 929}]}
-                              :constant-test {puppetlabs.kitchensink.core-test [{:line 731}
-                                                                                {:line 738}]}}
+                              :constant-test {puppetlabs.kitchensink.core-test [{:line 716}
+                                                                                {:line 723}]}}
              :continue-on-exception true}
 
   :test-selectors {:default (complement :slow)

--- a/src/puppetlabs/kitchensink/core.clj
+++ b/src/puppetlabs/kitchensink/core.clj
@@ -6,10 +6,7 @@
 
 (ns puppetlabs.kitchensink.core
   (:refer-clojure :exclude [boolean? uuid?])
-  (:require [clj-time.coerce :as time-coerce]
-            [clj-time.core :as time]
-            [clj-time.format :as time-format]
-            [clojure.java.io :as io]
+  (:require [clojure.java.io :as io]
             [clojure.pprint :as pprint]
             [clojure.set :as set]
             [clojure.string :as string]
@@ -19,7 +16,7 @@
             [me.raynes.fs :as fs]
             [slingshot.slingshot :refer [throw+]])
   (:import (java.io File Reader StringWriter)
-           (java.time ZoneId ZoneOffset ZonedDateTime)
+           (java.time Duration ZoneId ZoneOffset ZonedDateTime)
            (java.time.format DateTimeFormatter)
            javax.naming.ldap.LdapName
            (javax.naming.ldap Rdn)
@@ -38,14 +35,6 @@
   (some-> x
     (class)
     (.isArray)))
-
-(defn datetime?
-  "Predicate returning whether or not the supplied object is
-  convertible to a Joda DateTime"
-  [x]
-  (and
-    (satisfies? time-coerce/ICoerce x)
-    (time-coerce/to-date-time x)))
 
 (defn boolean?
   "Returns true if the value is a boolean"
@@ -612,16 +601,6 @@ to be a zipper."
     (map sort-nested-maps data)
     :else data))
 
-;; ## Date and Time
-
-(defn timestamp
-  "Returns a timestamp string for the given `time`, or the current time if none
-  is provided. The format of the timestamp is eg. 2012-02-23T22:01:39.539Z."
-  ([]
-   (timestamp (time/now)))
-  ([time]
-   (time-format/unparse (time-format/formatters :date-time) time)))
-
 ;; ## Exception handling
 
 (defn without-ns
@@ -1166,11 +1145,11 @@ to be a zipper."
 
 (defn parse-interval
   "Given a time string of the form \"<number>\", or \"<number><unit>\", this
-  function parses this time amount and returns a joda time Period instance.
+  function parses this time amount and returns a java.time.Duration instance.
   If the unit is left off, the units are assumed to be time/seconds
 
-  Example: \"12h\" -> (clj-time.core/hours 12)
-  Example: \"12\" -> (clj-time.core/seconds 12)
+  Example: \"12h\" -> (Duration/ofHours 12)
+  Example: \"12\" -> (Duration/ofSeconds 12)
 
   Possible units: s(econds), m(inutes), h(ours), d(ays), y(ears)
 
@@ -1180,12 +1159,12 @@ to be a zipper."
     (when-let [[_ num unit] (re-matches #"^(\d+)([smhdy]?)$" time-str)]
       (let [num (parse-int num)
             time-fn (case unit
-                      "s" time/seconds
-                      "m" time/minutes
-                      "h" time/hours
-                      "d" time/days
-                      "y" time/years
-                      "" time/seconds)]
+                      "s" #(Duration/ofSeconds %)
+                      "m" #(Duration/ofMinutes %)
+                      "h" #(Duration/ofHours %)
+                      "d" #(Duration/ofDays %)
+                      "y" #(Duration/ofDays (* 365 %))
+                      ""  #(Duration/ofSeconds %))]
         (time-fn num)))))
 
 ;; ## HTTP Headers

--- a/src/puppetlabs/kitchensink/json.clj
+++ b/src/puppetlabs/kitchensink/json.clj
@@ -13,19 +13,12 @@
   (:require
     [cheshire.core :as core]
     [cheshire.generate :as generate]
-    [clj-time.coerce :as coerce]
-    [clj-time.core :as clj-time]
     [clojure.java.io :as io]
     [clojure.tools.logging :as log])
   (:import
     com.fasterxml.jackson.core.JsonGenerator
     (java.time Instant LocalDate LocalDateTime)))
 
-(defn- clj-time-encoder
-  [data jsonGenerator]
-  (.writeString ^JsonGenerator jsonGenerator ^String (coerce/to-string data)))
-
-(def ^:dynamic *datetime-encoder* clj-time-encoder)
 
 (defn- java-instant-encoder
   [^Instant data jsonGenerator]
@@ -48,18 +41,12 @@
 (defn add-common-json-encoders!*
   "Non-memoize version of add-common-json-encoders!"
   []
-  (when (satisfies? generate/JSONable (clj-time/date-time 1999))
-    (log/warn "Overriding existing JSONable protocol implementation for org.joda.time.DateTime"))
   (when (satisfies? generate/JSONable (Instant/now))
     (log/warn "Overriding existing JSONable protocol implementation for java.time.Instant"))
   (when (satisfies? generate/JSONable (LocalDateTime/now))
     (log/warn "Overriding existing JSONable protocol implementation for java.time.LocalDateTime"))
   (when (satisfies? generate/JSONable (LocalDate/now))
     (log/warn "Overriding existing JSONable protocol implementation for java.time.LocalDate"))
-  (generate/add-encoder
-    org.joda.time.DateTime
-    (fn [data jsonGenerator]
-      (*datetime-encoder* data jsonGenerator)))
   (generate/add-encoder
     java.time.Instant
     (fn [data jsonGenerator]
@@ -78,22 +65,16 @@
 
   This is a memoize function, to avoid unnecessary calls to add-encoder.
 
-  Ideally this function should be called once in your apply, for example your
+  Ideally this function should be called once in your app, for example your
   main class.
 
   Encoders currently include:
 
-  * org.joda.time.DateTime - handled with to-string"}
+  * java.time.Instant
+  * java.time.LocalDate
+  * java.time.LocalDateTime"}
   add-common-json-encoders! (memoize add-common-json-encoders!*))
 
-(defmacro with-datetime-encoder
-  "Evaluates the body using the given encoder to serialize DateTime objects to
-  JSON. Requires that `add-common-json-encoders!` from this namespace has
-  already been called, and that nobody else has re-extended
-  org.joda.date.DateTime to cheshire's JSONable protocol in the meantime."
-  [encoder & body]
-  `(binding [*datetime-encoder* ~encoder]
-     ~@body))
 
 (def default-pretty-opts {:date-format "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" :pretty true})
 
@@ -102,16 +83,16 @@
 (def ^String generate-stream core/generate-stream)
 
 (defn generate-pretty-string
-  "Thinly wraps cheshire.core/generate-string, adding the clj-time default date
-  format and pretty printing from `default-pretty-opts`"
+  "Thinly wraps cheshire.core/generate-string, adding pretty printing
+  from `default-pretty-opts`"
   ([obj]
      (generate-pretty-string obj default-pretty-opts))
   ([obj opts]
      (generate-string obj (merge default-pretty-opts opts))))
 
 (defn generate-pretty-stream
-  "Thinly wraps cheshire.core/generate-stream, adding the clj-time default date
-  format and pretty printing from `default-pretty-opts`"
+  "Thinly wraps cheshire.core/generate-stream, adding pretty printing
+  from `default-pretty-opts`"
   ([obj writer]
      (generate-pretty-stream obj writer default-pretty-opts))
   ([obj writer opts]

--- a/test/puppetlabs/kitchensink/core_test.clj
+++ b/test/puppetlabs/kitchensink/core_test.clj
@@ -1,6 +1,5 @@
 (ns puppetlabs.kitchensink.core-test
-  (:require [clj-time.core :as t]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [clojure.test :refer :all]
             [clojure.zip :as zip]
             [me.raynes.fs :as fs]
@@ -8,7 +7,7 @@
             [puppetlabs.kitchensink.testutils :as testutils]
             [slingshot.slingshot :refer [try+]])
   (:import (java.io ByteArrayInputStream File)
-           (java.time Month ZonedDateTime)
+           (java.time Duration Month ZonedDateTime)
            (java.time.format DateTimeParseException)
            (java.util ArrayList)))
 
@@ -42,20 +41,6 @@
   (is (core/regexp? #"test"))
   (testing "should return false if string"
     (is (not (core/regexp? "test")))))
-
-(deftest datetime?-test
-  (testing "should return false for non-coercible types"
-    (is (not (core/datetime? 2.0))))
-  (testing "should return false for nil"
-    (is (not (core/datetime? nil))))
-  (testing "should return true for a valid string"
-    (is (core/datetime? "2011-01-01T12:00:00-03:00")))
-  (testing "should return false for an invalid string"
-    (is (not (core/datetime? "foobar"))))
-  (testing "should return true for a valid integer"
-    (is (core/datetime? 20)))
-  (testing "should return false for an invalid integer")
-  (is (not (core/datetime? -9999999999999999999999999999999))))
 
 (deftest zipper?-test
   (testing "should return true for zippers"
@@ -848,13 +833,13 @@
 
 (deftest parse-interval-test
   (are [x y] (= x (core/parse-interval y))
-    (t/seconds 11) "11s"
-    (t/minutes 12) "12m"
-    (t/hours 13) "13h"
-    (t/days 14) "14d"
-    (t/years 15) "15y"
-    (t/seconds 0) "0"
-    (t/seconds 10) "10"
+    (Duration/ofSeconds 11) "11s"
+    (Duration/ofMinutes 12) "12m"
+    (Duration/ofHours 13) "13h"
+    (Duration/ofDays 14) "14d"
+    (Duration/ofDays (* 15 365)) "15y"
+    (Duration/ofSeconds 0) "0"
+    (Duration/ofSeconds 10) "10"
     nil "15a"
     nil "h"
     nil "12hhh"

--- a/test/puppetlabs/kitchensink/json_test.clj
+++ b/test/puppetlabs/kitchensink/json_test.clj
@@ -1,11 +1,9 @@
 (ns puppetlabs.kitchensink.json-test
   (:require
-    [clj-time.core :as clj-time]
     [puppetlabs.kitchensink.core :refer [temp-file]]
     [puppetlabs.kitchensink.json :as ks-json])
   (:use [clojure.test])
   (:import
-    (com.fasterxml.jackson.core JsonGenerator)
     (java.io StringReader StringWriter)
     (java.time Instant LocalDate LocalDateTime)))
 
@@ -16,26 +14,17 @@
 
 (use-fixtures :once add-common-encoders-fixture)
 
-(deftest test-with-custom-datetime-encoder
-  (testing "should allow use of custom encoder"
-    (is (= (ks-json/with-datetime-encoder (fn [_dt gn8r] (.writeString ^JsonGenerator gn8r "Beer-o-clock"))
-             (ks-json/generate-string (clj-time/date-time 1989 11 17 5 6 24 654)))
-           "\"Beer-o-clock\""))))
-
 (deftest test-generate-string
   (testing "should generate a json string"
     (is (= (ks-json/generate-string {:a 1 :b 2})
            "{\"a\":1,\"b\":2}")))
-  (testing "should generate a json string that has a Joda DataTime object in it and not explode"
-    (is (= (ks-json/generate-string {:a 1 :b (clj-time/date-time 1986 10 14 4 3 27 456)})
-           "{\"a\":1,\"b\":\"1986-10-14T04:03:27.456Z\"}")))
   (testing "should generate a json string that has a java.time.Instant in it and not explode"
     (is (= (ks-json/generate-string {:a 1 :b (Instant/parse "1994-09-19T21:00:30Z")})
            "{\"a\":1,\"b\":\"1994-09-19T21:00:30Z\"}")))
   (testing "should generate a json string that has a java.time.LocalDate in it and not explode"
     (is (= (ks-json/generate-string {:a 1 :b (LocalDate/parse "1953-05-29")})
            "{\"a\":1,\"b\":\"1953-05-29\"}")))
-  (testing "should generate a json string that has a java.time.Instant in it and not explode"
+  (testing "should generate a json string that has a java.time.LocalDateTime in it and not explode"
     (is (= (ks-json/generate-string {:a 1 :b (LocalDateTime/parse "1954-07-31T21:00:30")})
            "{\"a\":1,\"b\":\"1954-07-31T21:00:30\"}"))))
 
@@ -43,16 +32,13 @@
   (testing "should generate a json string"
     (is (= (ks-json/generate-pretty-string {:a 1 :b 2})
            "{\n  \"a\" : 1,\n  \"b\" : 2\n}")))
-  (testing "should generate a json string that has a Joda DataTime object in it and not explode"
-    (is (= (ks-json/generate-pretty-string {:a 1 :b (clj-time/date-time 1986 10 14 4 3 27 456)})
-           "{\n  \"a\" : 1,\n  \"b\" : \"1986-10-14T04:03:27.456Z\"\n}")))
   (testing "should generate a json string that has a java.time.Instant in it and not explode"
     (is (= (ks-json/generate-pretty-string {:a 1 :b (Instant/parse "1994-09-19T21:00:30Z")})
            "{\n  \"a\" : 1,\n  \"b\" : \"1994-09-19T21:00:30Z\"\n}")))
   (testing "should generate a json string that has a java.time.LocalDate in it and not explode"
     (is (= (ks-json/generate-pretty-string {:a 1 :b (LocalDate/parse "1953-05-29")})
            "{\n  \"a\" : 1,\n  \"b\" : \"1953-05-29\"\n}")))
-  (testing "should generate a json string that has a java.time.Instant in it and not explode"
+  (testing "should generate a json string that has a java.time.LocalDateTime in it and not explode"
     (is (= (ks-json/generate-pretty-string {:a 1 :b (LocalDateTime/parse "1954-07-31T21:00:30")})
            "{\n  \"a\" : 1,\n  \"b\" : \"1954-07-31T21:00:30\"\n}"))))
 


### PR DESCRIPTION
- remove clj-time which was used to transitively bring in Joda Time